### PR TITLE
fix: RSS-ECOMM-2_19-fix add right url to the registration page

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -121,6 +121,8 @@ export default class App {
       } else {
         this.renderPageByRoute('login');
       }
+    } else if (startingRoute === 'registration') {
+      this.renderPageByRoute('registration');
     } else if (routes[startingRoute]) {
       this.renderPageByRoute(startingRoute);
     } else {


### PR DESCRIPTION
Was done:
- Users can directly access the registration page by typing its URL into the browser's address bar. 📝