### PR TITLE
feat: RSS-ECOMM-3_20(19) add routing implementation between catalog page and product page

### DIFF
--- a/src/components/catalog/catalogView.ts
+++ b/src/components/catalog/catalogView.ts
@@ -83,6 +83,21 @@ export default class Catalog {
         this.filter(checkboxAll, sortSelect, priceInputAll);
       });
     });
+
+    const catalogGallery = document.querySelector('.catalog__gallery');
+    if (catalogGallery) {
+      catalogGallery.addEventListener('click', (event) => {
+        const target = event.target as HTMLElement;
+        const productCard = target.closest('.product-card');
+        if (productCard) {
+          const productId = productCard.id;
+          const productEvent = new CustomEvent('productEvent', {
+            detail: { id: productId },
+          });
+          document.body.dispatchEvent(productEvent);
+        }
+      });
+    }
   }
 
   async filter(

--- a/src/components/detailedProduct/detailedProduct.scss
+++ b/src/components/detailedProduct/detailedProduct.scss
@@ -1,20 +1,20 @@
 .detailed__product {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  @include flexbox(column, center);
   align-items: center;
   width: 100vw;
   height: 100%;
 }
+
 .detailed__product-container {
-  height: inherit;
-  max-width: 1200px;
-  padding: 15px;
-  margin: 0 auto;
+  height: 74vh;
+  width: 100vw;
+  padding-top: 20px;
+  overflow-y: auto;
 }
+
 .detailed__product-wrapper {
-  max-width: 1000px;
   margin: 0 auto;
+  @include flexbox(column, center);
 }
 
 .swiper {
@@ -27,6 +27,7 @@
   height: inherit;
   object-fit: cover;
 }
+
 .swiper-pagination {
   position: absolute;
   text-align: center;
@@ -35,6 +36,7 @@
   z-index: 10;
   height: 105px;
 }
+
 .swiper-pagination-bullet {
   background-image: url('./assets/1314467.svg');
   height: 50px;

--- a/src/components/router.ts
+++ b/src/components/router.ts
@@ -13,6 +13,15 @@ class Router {
 
   private handleRouteChange() {
     const currentRoute = window.location.pathname;
+    const isProductPage = currentRoute.startsWith('/product');
+    if (isProductPage) {
+      const handler = this.routes['/product?id=id'];
+      if (handler) {
+        handler();
+        return;
+      }
+    }
+
     const handler = this.routes[currentRoute];
     if (handler) {
       handler();


### PR DESCRIPTION
Was done:
🔨 Implementation Details
- Catalog Page: This page should display a list of products. Each product card should contain a link (or be a link itself) directing to the corresponding product's detail page.
- Product Detail Page: This page should display detailed information about a single product. It should be accessible by clicking on a product card from the Catalog page or by directly accessing a unique URL for the product.
- Routing: The URL in the browser should change when users navigate from the Catalog page to a Product Detail page and vice versa. Each product should have a unique URL that can be directly accessed to view its details.
- Browser Navigation Buttons: Implement support for browser navigation buttons. If a user navigates to a different product detail page or the Catalog page, the back button should take the user to the previously viewed page. The forward button should work correspondingly after using the back button.
- Public Accessibility: The Catalog and Product Detail pages should be accessible whether the user is logged in or not. These pages should not require authentication.